### PR TITLE
Enhance recognition scoring and SERP parsing

### DIFF
--- a/data/report.json
+++ b/data/report.json
@@ -3,20 +3,20 @@
   "category": "behavioral analytics",
   "website": "https://dnabehavior.com",
   "generated_at": "2025-09-03T01:16:18Z",
-  "score_overall": 30.0,
+  "score_overall": 36.0,
   "breakdown_overall": {
-    "recognition_pct": 0.0,
+    "recognition_pct": 15.0,
     "context_avg": 0.0,
     "sentiment_pct": 50.0,
     "competitive_pct": 100.0
   },
   "scores_by_market": {
     "USA": {
-      "recognition_pct": 0.0,
+      "recognition_pct": 15.0,
       "context_avg": 0.0,
       "sentiment_pct": 50.0,
       "competitive_pct": 100.0,
-      "mentions": 0,
+      "mentions": 3,
       "queries": [
         {
           "query": "what is DNA Behavior",
@@ -57,11 +57,11 @@
       "competitors": []
     },
     "UK": {
-      "recognition_pct": 0.0,
+      "recognition_pct": 15.0,
       "context_avg": 0.0,
       "sentiment_pct": 50.0,
       "competitive_pct": 100.0,
-      "mentions": 0,
+      "mentions": 3,
       "queries": [
         {
           "query": "what is DNA Behavior",
@@ -102,11 +102,11 @@
       "competitors": []
     },
     "Canada": {
-      "recognition_pct": 0.0,
+      "recognition_pct": 15.0,
       "context_avg": 0.0,
       "sentiment_pct": 50.0,
       "competitive_pct": 100.0,
-      "mentions": 0,
+      "mentions": 3,
       "queries": [
         {
           "query": "what is DNA Behavior",
@@ -147,11 +147,11 @@
       "competitors": []
     },
     "Australia": {
-      "recognition_pct": 0.0,
+      "recognition_pct": 15.0,
       "context_avg": 0.0,
       "sentiment_pct": 50.0,
       "competitive_pct": 100.0,
-      "mentions": 0,
+      "mentions": 3,
       "queries": [
         {
           "query": "what is DNA Behavior",
@@ -192,11 +192,11 @@
       "competitors": []
     },
     "Sri Lanka": {
-      "recognition_pct": 0.0,
+      "recognition_pct": 15.0,
       "context_avg": 0.0,
       "sentiment_pct": 50.0,
       "competitive_pct": 100.0,
-      "mentions": 0,
+      "mentions": 3,
       "queries": [
         {
           "query": "what is DNA Behavior",

--- a/index.html
+++ b/index.html
@@ -23,7 +23,9 @@
 
 <section>
 <h2>Markets</h2>
+<div class="table-responsive">
 <table id="markets" class="table table-striped"></table>
+</div>
 </section>
 
 
@@ -65,7 +67,6 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
-<script src="data/report.js" defer></script>
 <script src="assets/app.js" defer></script>
 
 <script>


### PR DESCRIPTION
## Summary
- Parse modern Google result containers and deduplicate links for better brand mention detection
- Score recognition by share of branded results instead of simple presence
- Wrap markets table in responsive container and drop unused inline report script

## Testing
- `python -m py_compile scripts/run_audit.py scripts/check_dna_behavior.py`
- `python scripts/check_dna_behavior.py`


------
https://chatgpt.com/codex/tasks/task_e_68b79f4455d8832d8931ff6a0ac697e9