### PR TITLE
feat: add static GEO Grader report

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,85 +1,166 @@
-function formatCurrency(n){
-  return new Intl.NumberFormat('en-US',{style:'currency',currency:'USD'}).format(n);
+const data = {
+  updatedAt: "2025-09-03",
+  score: 78,
+  markets: [
+    {label: "US", value: 45},
+    {label: "EU", value: 30},
+    {label: "Asia", value: 25}
+  ],
+  competitors: [
+    {name: "AlphaLabs", score: 82, note: "Technical content edge"},
+    {name: "BrandCo", score: 75, note: "Strong PR, weak CWV"},
+    {name: "SearchSmith", score: 71, note: "Good backlinks, thin content"}
+  ],
+  onsite: { lcpSec: 2.7, cls: 0.08, mobile: "Good", brokenLinks: 12, pageSpeed: 86, metadata: "OK" },
+  offsite: { backlinks: 1240, referringDomains: 220, mentions: 310, trend: [62,64,66,70,72,74,76,79,80] },
+  recommendations: [
+    {action:"Compress hero images", why:"LCP", effort:"Low", impact:"High"},
+    {action:"Add Organization schema", why:"Rich results", effort:"Low", impact:"Medium"},
+    {action:"Fix 12 broken links", why:"Crawlability", effort:"Medium", impact:"Medium"},
+    {action:"Improve mobile font sizes", why:"UX", effort:"Low", impact:"Medium"},
+    {action:"Add internal links to cornerstone pages", why:"Distribution", effort:"Low", impact:"Medium"},
+    {action:"Write unique H1s on 8 pages", why:"Relevance", effort:"Medium", impact:"Medium"},
+    {action:"Minify CSS", why:"Load", effort:"Low", impact:"Medium"},
+    {action:"Add blog cadence 2 posts/month", why:"Freshness", effort:"Medium", impact:"Medium"},
+    {action:"Build 5 authority backlinks", why:"Off-site trust", effort:"High", impact:"High"},
+    {action:"Set up analytics goals", why:"Measure ROI", effort:"Medium", impact:"High"}
+  ]
+};
+
+const $ = id => document.getElementById(id);
+
+function renderScore(){
+  $("updated-date").textContent = data.updatedAt;
+  $("score-value").textContent = data.score;
+  const radius = 45;
+  const circ = 2 * Math.PI * radius;
+  const ring = $("score-ring");
+  ring.setAttribute("stroke-dasharray", circ);
+  ring.setAttribute("stroke-dashoffset", circ * (1 - data.score / 100));
+  const summary = data.score >= 80 ? "Strong SEO health." : data.score >= 60 ? "Solid foundation with room to grow." : "Needs significant work.";
+  $("score-summary").textContent = summary;
 }
-function formatPercent(n){
-  return new Intl.NumberFormat('en-US',{style:'percent',minimumFractionDigits:1,maximumFractionDigits:1}).format(n);
-}
-function renderDelta(v){
-  const cls=v>=0?'up':'down';
-  const arrow=v>=0?'▲':'▼';
-  return `<span class="delta ${cls}">${arrow} ${formatPercent(Math.abs(v))}</span>`;
-}
-function copyToClipboard(id){
-  const el=document.getElementById(id);
-  navigator.clipboard.writeText(el.textContent).then(()=>{
-    const toast=document.getElementById('copyToast');
-    toast.textContent='Copied!';
-    setTimeout(()=>toast.textContent='',2000);
-  });
-}
-function closeSidebar(){
-  document.getElementById('sidebar').classList.remove('open','expanded');
-  document.getElementById('overlay').classList.remove('show');
-  document.getElementById('menuBtn').setAttribute('aria-expanded','false');
-}
-async function init(){
-  const res=await fetch('data/report.json');
-  const data=await res.json();
-  document.getElementById('score').textContent=data.overallScore;
-  document.getElementById('delta').innerHTML=renderDelta(data.delta);
-  document.getElementById('topSales').textContent=data.topSales;
-  document.getElementById('bestDealValue').textContent=formatCurrency(data.bestDeal.value);
-  document.getElementById('bestDealCompany').textContent=data.bestDeal.company;
-  document.getElementById('totalDeals').textContent=data.totalDeals;
-  document.getElementById('jsonld').textContent=JSON.stringify(data.jsonld,null,2);
-  const comp=document.getElementById('competitors');
-  data.competitors.forEach(c=>{
-    const li=document.createElement('li');
-    li.innerHTML=`<span><img src="${c.logo}" alt=""/> ${c.name}</span><span>${c.score}</span>`;
-    comp.appendChild(li);
-  });
-  const rec=document.getElementById('recommendations');
-  data.recommendations.forEach(r=>{
-    const li=document.createElement('li');
-    li.innerHTML=`<h4>${r.title}</h4><p>${r.why}</p><span class="tag impact-${r.impact.toLowerCase()}">${r.impact}</span><span class="tag effort-${r.effort.toLowerCase()}">Effort: ${r.effort}</span>`;
-    rec.appendChild(li);
-  });
-  new Chart(document.getElementById('marketsChart'),{
-    type:'doughnut',
-    data:{labels:data.markets.map(m=>m.platform),datasets:[{data:data.markets.map(m=>m.share),backgroundColor:['#ff4d6d','#5b7cfa','#2ec9b8','#16a34a','#ef4444']}]},
-    options:{plugins:{legend:{position:'bottom'}}}
-  });
-  new Chart(document.getElementById('siteChart'),{
-    type:'bar',
-    data:{labels:data.siteSignals.labels,datasets:[{label:'Site',data:data.siteSignals.values,backgroundColor:'#5b7cfa'}]},
-    options:{scales:{y:{beginAtZero:true}}}
-  });
-  new Chart(document.getElementById('offsiteChart'),{
-    type:'bar',
-    data:{labels:data.offSiteSignals.labels,datasets:[{label:'Off-site',data:data.offSiteSignals.values,backgroundColor:'#2ec9b8'}]},
-    options:{scales:{y:{beginAtZero:true}}}
-  });
-  new Chart(document.getElementById('referrerChart'),{
-    type:'bar',
-    data:{labels:data.dealsByReferrer.labels,datasets:[{data:data.dealsByReferrer.values,backgroundColor:'#ff4d6d'}]},
-    options:{scales:{y:{beginAtZero:true}}}
+
+function renderMarkets(){
+  const container = $("markets-bars");
+  data.markets.forEach(m => {
+    const row = document.createElement("div");
+    row.className = "flex items-center space-x-2";
+    row.innerHTML = `<span class="w-12">${m.label}</span>
+      <div class="flex-1 bg-gray-200 rounded h-3"><div class="bg-blue-600 h-3 rounded" style="width:${m.value}%"></div></div>
+      <span class="w-10 text-right">${m.value}%</span>`;
+    container.appendChild(row);
   });
 }
-document.getElementById('copyJsonld').addEventListener('click',()=>copyToClipboard('jsonld'));
-document.getElementById('menuBtn').addEventListener('click',()=>{
-  const sb=document.getElementById('sidebar');
-  const overlay=document.getElementById('overlay');
-  const expanded=sb.classList.toggle(window.innerWidth>=640?'expanded':'open');
-  if(window.innerWidth<640) overlay.classList.toggle('show');
-  document.getElementById('menuBtn').setAttribute('aria-expanded',expanded);
-});
-document.getElementById('overlay').addEventListener('click',closeSidebar);
-document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSidebar();});
-document.querySelectorAll('.submenu').forEach(btn=>{
-  btn.addEventListener('click',()=>{
-    const expanded=btn.getAttribute('aria-expanded')==='true';
-    btn.setAttribute('aria-expanded',!expanded);
-    document.getElementById(btn.getAttribute('aria-controls')).hidden=expanded;
+
+function renderCompetitors(){
+  const container = $("competitor-cards");
+  data.competitors.forEach(c => {
+    const li = document.createElement("li");
+    li.className = "p-4 bg-white rounded shadow flex items-center space-x-3";
+    li.innerHTML = `<div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-lg font-bold" aria-hidden="true">${c.name.charAt(0)}</div>
+      <div class="flex-1"><h3 class="font-semibold">${c.name}</h3><p class="text-sm text-gray-600">${c.note}</p></div>
+      <span class="px-2 py-1 text-sm rounded bg-blue-100 text-blue-800 font-medium">${c.score}</span>`;
+    container.appendChild(li);
   });
-});
-init();
+}
+
+function renderOnsite(){
+  const container = $("onsite-grid");
+  const items = [
+    {label:"Page Speed", value:`${data.onsite.pageSpeed}`, type:"bar"},
+    {label:"LCP", value:`${data.onsite.lcpSec}s`},
+    {label:"CLS", value:data.onsite.cls},
+    {label:"Mobile", value:data.onsite.mobile},
+    {label:"Broken Links", value:data.onsite.brokenLinks},
+    {label:"Metadata", value:data.onsite.metadata}
+  ];
+  items.forEach(it => {
+    const div = document.createElement("div");
+    div.className = "p-4 bg-white rounded shadow";
+    div.innerHTML = `<h3 class="font-medium mb-2">${it.label}</h3>`;
+    if(it.type === "bar"){
+      div.innerHTML += `<div class="w-full bg-gray-200 rounded h-2"><div class="bg-green-500 h-2 rounded" style="width:${it.value}%"></div></div><p class="mt-1 text-sm">${it.value}</p>`;
+    }else{
+      div.innerHTML += `<p class="text-lg font-semibold">${it.value}</p>`;
+    }
+    container.appendChild(div);
+  });
+}
+
+function renderOffsite(){
+  const statsContainer = $("offsite-stats");
+  const stats = [
+    {label:"Backlinks", value:data.offsite.backlinks},
+    {label:"Referring domains", value:data.offsite.referringDomains},
+    {label:"Brand mentions", value:data.offsite.mentions}
+  ];
+  stats.forEach(s => {
+    const div = document.createElement("div");
+    div.innerHTML = `<div class="text-xl font-semibold">${s.value.toLocaleString()}</div><p class="text-sm text-gray-600">${s.label}</p>`;
+    statsContainer.appendChild(div);
+  });
+  const values = data.offsite.trend;
+  const w = 100, h = 30;
+  const max = Math.max(...values), min = Math.min(...values);
+  const points = values.map((v,i) => {
+    const x = i / (values.length - 1) * w;
+    const y = h - ((v - min) / (max - min) * h);
+    return `${x},${y}`;
+  }).join(" ");
+  $("trend-line").setAttribute("points", points);
+}
+
+function renderRecommendations(){
+  const list = $("recommendations-list");
+  data.recommendations.forEach(r => {
+    const li = document.createElement("li");
+    li.className = "space-y-1";
+    li.innerHTML = `<div class="flex items-center justify-between flex-wrap gap-2">
+        <span class="font-medium">${r.action}</span>
+        <div class="flex items-center gap-2">
+          <span class="px-2 py-0.5 rounded bg-gray-200 text-xs">Effort: ${r.effort}</span>
+          <span class="px-2 py-0.5 rounded bg-blue-200 text-xs">Impact: ${r.impact}</span>
+        </div>
+      </div>
+      <p class="text-sm text-gray-600">${r.why}</p>`;
+    list.appendChild(li);
+  });
+}
+
+function renderJsonLd(){
+  const json = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Example Corp",
+    "url": "https://example.com",
+    "logo": "https://example.com/logo.png",
+    "sameAs": [
+      "https://twitter.com/example",
+      "https://www.linkedin.com/company/example"
+    ]
+  };
+  $("jsonld").value = JSON.stringify(json, null, 2);
+}
+
+function enableCopy(){
+  $("copy-jsonld").addEventListener("click", () => {
+    navigator.clipboard.writeText($("jsonld").value).then(() => {
+      $("copy-msg").textContent = "Copied!";
+      setTimeout(() => $("copy-msg").textContent = "", 2000);
+    });
+  });
+}
+
+function init(){
+  renderScore();
+  renderMarkets();
+  renderCompetitors();
+  renderOnsite();
+  renderOffsite();
+  renderRecommendations();
+  renderJsonLd();
+  enableCopy();
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/index.html
+++ b/index.html
@@ -3,152 +3,107 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Analytics Dashboard</title>
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="styles.css">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
-  <script src="app.js" defer></script>
+  <title>GEO Grader</title>
+  <meta name="description" content="Weekly snapshot of on-site and off-site signals for your site.">
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-  <aside class="sidebar" id="sidebar">
-    <button class="sidebar-toggle" id="menuBtn" aria-label="Toggle menu" aria-expanded="false">
-      <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
-    </button>
-    <nav aria-label="Main navigation">
-      <ul class="menu">
+<body class="bg-gray-50 text-gray-900">
+  <header class="bg-white shadow">
+    <div class="max-w-5xl mx-auto px-4 py-6">
+      <h1 class="text-3xl font-bold">GEO Grader</h1>
+      <p class="text-sm text-gray-600">Input your site. Get a weekly snapshot of on-site and off-site signals.</p>
+      <p class="text-xs text-gray-500 mt-1">Last updated: <span id="updated-date"></span></p>
+    </div>
+  </header>
+  <main class="max-w-5xl mx-auto px-4 py-8 space-y-8">
+    <!-- Overall Score -->
+    <section aria-labelledby="overall-score">
+      <h2 id="overall-score" class="sr-only">Overall Score</h2>
+      <div class="flex items-center space-x-6">
+        <div class="relative w-32 h-32">
+          <svg viewBox="0 0 100 100" class="transform -rotate-90">
+            <circle cx="50" cy="50" r="45" stroke="#e5e7eb" stroke-width="10" fill="none" />
+            <circle id="score-ring" cx="50" cy="50" r="45" stroke="#3b82f6" stroke-width="10" stroke-dasharray="0" stroke-dashoffset="0" stroke-linecap="round" fill="none" />
+          </svg>
+          <span id="score-value" class="absolute inset-0 flex items-center justify-center text-2xl font-semibold"></span>
+        </div>
+        <p id="score-summary" class="text-lg"></p>
+      </div>
+    </section>
+
+    <!-- Markets -->
+    <section aria-labelledby="markets">
+      <h2 id="markets" class="text-xl font-semibold mb-4">Markets</h2>
+      <div id="markets-bars" class="space-y-3"></div>
+      <p class="mt-2 text-sm text-gray-600">Audience concentrated in the US.</p>
+    </section>
+
+    <!-- Top Competitors -->
+    <section aria-labelledby="competitors">
+      <h2 id="competitors" class="text-xl font-semibold mb-4">Top Competitors</h2>
+      <ul id="competitor-cards" class="grid gap-4 sm:grid-cols-3"></ul>
+    </section>
+
+    <!-- Site Signals -->
+    <section aria-labelledby="onsite-signals">
+      <h2 id="onsite-signals" class="text-xl font-semibold mb-4">Site Signals (On-site)</h2>
+      <div id="onsite-grid" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3"></div>
+    </section>
+
+    <!-- Off-site Signals -->
+    <section aria-labelledby="offsite-signals">
+      <h2 id="offsite-signals" class="text-xl font-semibold mb-4">Off-site Signals</h2>
+      <div id="offsite-stats" class="grid grid-cols-2 sm:grid-cols-4 gap-4 text-center"></div>
+      <div class="mt-4">
+        <svg id="trend" viewBox="0 0 100 30" class="w-full h-8 text-blue-600" aria-label="90-day trend">
+          <polyline id="trend-line" fill="none" stroke="currentColor" stroke-width="2" points="" />
+        </svg>
+      </div>
+    </section>
+
+    <!-- Recommendations -->
+    <section aria-labelledby="recommendations">
+      <h2 id="recommendations" class="text-xl font-semibold mb-4">Recommendations (Top 10)</h2>
+      <ol id="recommendations-list" class="space-y-4 list-decimal ml-5"></ol>
+    </section>
+
+    <!-- 90-Day Plan -->
+    <section aria-labelledby="plan">
+      <h2 id="plan" class="text-xl font-semibold mb-4">90-Day Plan</h2>
+      <ul class="space-y-4">
         <li>
-          <button class="submenu" aria-expanded="false" aria-controls="grp-dashboard">
-            <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M3 3h8v8H3V3zm10 0h8v5h-8V3zM3 13h5v8H3v-8zm7 3h11v5H10v-5z" fill="currentColor"/></svg>
-            <span>Dashboard</span>
-          </button>
-          <ul id="grp-dashboard" class="sub" hidden>
-            <li><a href="#">Overview</a></li>
-            <li><a href="#">Updates</a></li>
-          </ul>
+          <h3 class="font-medium">Weeks 1–2</h3>
+          <p class="text-sm text-gray-600">Core Web Vitals fixes, broken links, metadata refresh.</p>
         </li>
         <li>
-          <button class="submenu" aria-expanded="false" aria-controls="grp-reports">
-            <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M4 4h16v4H4V4zm0 6h10v4H4v-4zm0 6h16v4H4v-4z" fill="currentColor"/></svg>
-            <span>Reports</span>
-          </button>
-          <ul id="grp-reports" class="sub" hidden>
-            <li><a href="#">Monthly</a></li>
-            <li><a href="#">Weekly</a></li>
-          </ul>
+          <h3 class="font-medium">Weeks 3–4</h3>
+          <p class="text-sm text-gray-600">Schema, internal linking, image compression, minify CSS.</p>
         </li>
         <li>
-          <button class="submenu" aria-expanded="false" aria-controls="grp-insights">
-            <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M12 2a7 7 0 00-7 7c0 3.5 2.5 6.4 5.9 6.9V19H8v3h8v-3h-2.9v-3.1C16.5 15.4 19 12.5 19 9a7 7 0 00-7-7z" fill="currentColor"/></svg>
-            <span>Insights</span>
-          </button>
-          <ul id="grp-insights" class="sub" hidden>
-            <li><a href="#">Trends</a></li>
-            <li><a href="#">Segments</a></li>
-          </ul>
+          <h3 class="font-medium">Month 2</h3>
+          <p class="text-sm text-gray-600">Content cadence, keyword clustering, outreach for 5 backlinks.</p>
         </li>
         <li>
-          <button class="submenu" aria-expanded="false" aria-controls="grp-competitors">
-            <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M7 21l5-5 5 5V5a5 5 0 10-10 0v16z" fill="currentColor"/></svg>
-            <span>Competitors</span>
-          </button>
-          <ul id="grp-competitors" class="sub" hidden>
-            <li><a href="#">Leaderboard</a></li>
-            <li><a href="#">Share</a></li>
-          </ul>
-        </li>
-        <li>
-          <button class="submenu" aria-expanded="false" aria-controls="grp-recommendations">
-            <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M4 4h16v2H4V4zm2 4h12v2H6V8zm-2 4h16v2H4v-2zm2 4h12v2H6v-2z" fill="currentColor"/></svg>
-            <span>Recommendations</span>
-          </button>
-          <ul id="grp-recommendations" class="sub" hidden>
-            <li><a href="#">Top 10</a></li>
-            <li><a href="#">All</a></li>
-          </ul>
+          <h3 class="font-medium">Month 3</h3>
+          <p class="text-sm text-gray-600">Track KPIs, iterate, ship improvements.</p>
         </li>
       </ul>
-    </nav>
-  </aside>
-  <div class="overlay" id="overlay"></div>
-  <div class="content">
-    <header class="topbar">
-      <form class="search" role="search">
-        <label for="search" class="sr-only">Search insights</label>
-        <input id="search" type="search" placeholder="Search insights…" />
-      </form>
-      <div class="topbar-right">
-        <div class="avatars">
-          <img src="assets/avatar.svg" alt="User" />
-          <img src="assets/avatar.svg" alt="User" />
-          <img src="assets/avatar.svg" alt="User" />
-        </div>
-        <span class="tag">Updated weekly • no cookies</span>
+    </section>
+
+    <!-- JSON-LD -->
+    <section aria-labelledby="json-ld">
+      <h2 id="json-ld" class="text-xl font-semibold mb-4">Copy-ready JSON-LD</h2>
+      <textarea id="jsonld" class="w-full h-48 p-2 border rounded font-mono text-sm"></textarea>
+      <div class="mt-2 flex items-center space-x-4">
+        <button id="copy-jsonld" class="px-3 py-1 bg-blue-600 text-white rounded focus:outline-none focus:ring">Copy</button>
+        <a href="https://search.google.com/test/rich-results" target="_blank" class="text-blue-600 underline">Validate in Rich Results Test</a>
+        <span id="copy-msg" class="text-sm text-green-600" role="status"></span>
       </div>
-    </header>
-    <main>
-      <h1>New report</h1>
-      <section class="hero" aria-label="Key metrics">
-        <div class="card metric">
-          <h2>Overall Score</h2>
-          <div class="big-number"><span id="score">--</span><span id="delta"></span></div>
-        </div>
-        <div class="card">
-          <h3>Top Sales</h3>
-          <p id="topSales">--</p>
-        </div>
-        <div class="card">
-          <h3>Best Deal</h3>
-          <p><span id="bestDealValue">--</span><br><small id="bestDealCompany"></small></p>
-        </div>
-        <div class="card">
-          <h3>Total Deals</h3>
-          <p id="totalDeals">--</p>
-        </div>
-      </section>
-      <section class="grid widgets" aria-label="Charts and lists">
-        <div class="card">
-          <h3>Markets overview</h3>
-          <canvas id="marketsChart" aria-label="Market share" role="img"></canvas>
-        </div>
-        <div class="card">
-          <h3>Site Signals</h3>
-          <canvas id="siteChart" aria-label="Site signals" role="img"></canvas>
-        </div>
-        <div class="card">
-          <h3>Off-site Signals</h3>
-          <canvas id="offsiteChart" aria-label="Off-site signals" role="img"></canvas>
-        </div>
-        <div class="card">
-          <h3>Top Competitors</h3>
-          <ol id="competitors" class="leaderboard"></ol>
-        </div>
-        <div class="card">
-          <h3>Deals by referrer</h3>
-          <canvas id="referrerChart" aria-label="Deals by referrer" role="img"></canvas>
-        </div>
-        <div class="card recommendations">
-          <h3>Top 10 Recommendations</h3>
-          <ul id="recommendations" class="recommendations"></ul>
-        </div>
-        <div class="card code-block">
-          <h3>Copy-ready JSON-LD</h3>
-          <pre id="jsonld"></pre>
-          <button id="copyJsonld" class="copy" aria-live="polite">Copy</button>
-          <span id="copyToast" class="toast" aria-live="polite"></span>
-        </div>
-      </section>
-    </main>
-    <footer class="footer">
-      <a href="#">Methodology</a> • <a href="#">Changelog</a> • <a href="#">MIT License</a>
-    </footer>
-  </div>
-  <script>
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => {
-        navigator.serviceWorker.register('assets/sw.js');
-      });
-    }
-  </script>
+    </section>
+  </main>
+  <footer class="bg-white border-t">
+    <div class="max-w-5xl mx-auto px-4 py-6 text-sm text-gray-600">Generated weekly. Source: public web. No tracking. No cookies.</div>
+  </footer>
+  <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build single-page GEO Grader report with Tailwind styling
- render score ring, market bars, competitor cards, signals, recommendations and JSON-LD
- vanilla JS for data rendering, sparkline and copy button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a14cec74832d99f4bb15869c4913